### PR TITLE
feat: migrate to es modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "url": "https://github.com/kchung/mapkitjs-token/issues"
   },
   "license": "MIT",
+  "type": "module",
   "publishConfig": {
     "access": "public"
   },

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,10 +2,11 @@
 
 import fs from 'fs';
 import ms, { type StringValue } from 'ms';
-import yargs from 'yargs';
+import yargs from 'yargs/yargs';
+import { hideBin } from 'yargs/helpers';
 import chalk from 'chalk';
-import generate, { type GenerateOptions } from './generate';
-import verify from './verify';
+import generate, { type GenerateOptions } from './generate.js';
+import verify from './verify.js';
 
 type RunOptions = GenerateOptions & {
   verify: boolean;
@@ -17,7 +18,7 @@ const DOC_URL =
 
 const now = new Date();
 
-const argv = yargs.options({
+const argv = yargs(hideBin(process.argv)).options({
   alg: {
     default: 'ES256',
     defaultDescription: 'ES256',

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
-import generate from './generate';
-import verify from './verify';
+import generate from './generate.js';
+import verify from './verify.js';
 
 export {
   generate,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,9 +1,9 @@
 {
   "compilerOptions": {
     "target": "ES2020",
-    "module": "commonjs",
+    "module": "es2020",
     "lib": ["ES2020"],
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "esModuleInterop": true,
     "strict": true,
     "skipLibCheck": true,


### PR DESCRIPTION
Fixes an issue where `npx` doesn't work:

```
Error [ERR_REQUIRE_ESM]: require() of ES Module /[omit]/node_modules/chalk/source/index.js from /[omit]/node_modules/mapkitjs-token/dist/cli.js not supported.
Instead change the require of index.js in /[omit]/node_modules/mapkitjs-token/dist/cli.js to a dynamic import() which is available in all CommonJS modules.
```